### PR TITLE
Use built-in csv package when handling bulk requests & responses.

### DIFF
--- a/bulk/job.go
+++ b/bulk/job.go
@@ -1,15 +1,14 @@
 package bulk
 
 import (
-	"bufio"
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/namely/go-sfdc/v3"
 	"github.com/namely/go-sfdc/v3/session"
@@ -89,6 +88,17 @@ const (
 	JobComplete State = "JobComplete"
 	// Failed some records in the job failed.
 	Failed State = "Failed"
+)
+
+const (
+	// sfID is the column name for the Salesforce Object ID in Job CSV responses
+	sfID = "sf__Id"
+
+	// sfError is the column name for the error in Failed record responses
+	sfError = "sf__Error"
+
+	// sfError is the column name for the created flag in Successful record responses
+	sfCreated = "sf__Created"
 )
 
 // UnprocessedRecord is the unprocessed records from the job.
@@ -414,35 +424,31 @@ func (j *Job) SuccessfulRecords() ([]SuccessfulRecord, error) {
 		return nil, errMsg
 	}
 
-	scanner := bufio.NewScanner(response.Body)
+	reader := csv.NewReader(response.Body)
+	reader.Comma = j.delimiter()
 	defer response.Body.Close()
-	scanner.Split(bufio.ScanLines)
+
 	var records []SuccessfulRecord
-	delimiter := j.delimiter()
-	columns, err := j.recordResultHeader(scanner, delimiter)
+	fields, err := reader.Read()
 	if err != nil {
 		return nil, err
 	}
-	createIdx, err := j.headerPosition(`sf__Created`, columns)
-	if err != nil {
-		return nil, err
-	}
-	idIdx, err := j.headerPosition(`sf__Id`, columns)
-	if err != nil {
-		return nil, err
-	}
-	fields := j.fields(columns, 2)
-	for scanner.Scan() {
+	for {
+		values, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
 		var record SuccessfulRecord
-		values := strings.Split(scanner.Text(), delimiter)
-		isCreated := strings.Replace(values[createIdx], "\"", "", -1)
-		created, err := strconv.ParseBool(isCreated)
+		created, err := strconv.ParseBool(values[j.headerPosition(sfCreated, fields)])
 		if err != nil {
 			return nil, err
 		}
 		record.Created = created
-		record.ID = values[idIdx]
-		record.Fields = j.record(fields, values[2:])
+		record.ID = values[j.headerPosition(sfID, fields)]
+		record.Fields = j.record(fields[2:], values[2:])
 		records = append(records, record)
 	}
 
@@ -480,30 +486,27 @@ func (j *Job) FailedRecords() ([]FailedRecord, error) {
 		return nil, errMsg
 	}
 
-	scanner := bufio.NewScanner(response.Body)
+	reader := csv.NewReader(response.Body)
+	reader.Comma = j.delimiter()
 	defer response.Body.Close()
-	scanner.Split(bufio.ScanLines)
+
 	var records []FailedRecord
-	delimiter := j.delimiter()
-	columns, err := j.recordResultHeader(scanner, delimiter)
+	fields, err := reader.Read()
 	if err != nil {
 		return nil, err
 	}
-	errorIdx, err := j.headerPosition(`sf__Error`, columns)
-	if err != nil {
-		return nil, err
-	}
-	idIdx, err := j.headerPosition(`sf__Id`, columns)
-	if err != nil {
-		return nil, err
-	}
-	fields := j.fields(columns, 2)
-	for scanner.Scan() {
+	for {
+		values, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
 		var record FailedRecord
-		values := strings.Split(scanner.Text(), delimiter)
-		record.Error = values[errorIdx]
-		record.ID = values[idIdx]
-		record.Fields = j.record(fields, values[2:])
+		record.Error = values[j.headerPosition(sfError, fields)]
+		record.ID = values[j.headerPosition(sfID, fields)]
+		record.Fields = j.record(fields[2:], values[2:])
 		records = append(records, record)
 	}
 
@@ -541,19 +544,24 @@ func (j *Job) UnprocessedRecords() ([]UnprocessedRecord, error) {
 		return nil, errMsg
 	}
 
-	scanner := bufio.NewScanner(response.Body)
+	reader := csv.NewReader(response.Body)
+	reader.Comma = j.delimiter()
 	defer response.Body.Close()
-	scanner.Split(bufio.ScanLines)
+
 	var records []UnprocessedRecord
-	delimiter := j.delimiter()
-	columns, err := j.recordResultHeader(scanner, delimiter)
+	fields, err := reader.Read()
 	if err != nil {
 		return nil, err
 	}
-	fields := j.fields(columns, 0)
-	for scanner.Scan() {
+	for {
+		values, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
 		var record UnprocessedRecord
-		values := strings.Split(scanner.Text(), delimiter)
 		record.Fields = j.record(fields, values)
 		records = append(records, record)
 	}
@@ -561,26 +569,21 @@ func (j *Job) UnprocessedRecords() ([]UnprocessedRecord, error) {
 	return records, nil
 }
 
-func (j *Job) recordResultHeader(scanner *bufio.Scanner, delimiter string) ([]string, error) {
-	if scanner.Scan() == false {
-		return nil, errors.New("job: response needs to have header")
-	}
-	text := strings.Replace(scanner.Text(), "\"", "", -1)
-	return strings.Split(text, delimiter), nil
-}
-func (j *Job) headerPosition(column string, header []string) (int, error) {
+func (j *Job) headerPosition(column string, header []string) int {
 	for idx, col := range header {
 		if col == column {
-			return idx, nil
+			return idx
 		}
 	}
-	return -1, fmt.Errorf("job header: %s column is not in header", column)
+	return -1
 }
+
 func (j *Job) fields(header []string, offset int) []string {
 	fields := make([]string, len(header)-offset)
 	copy(fields[:], header[offset:])
 	return fields
 }
+
 func (j *Job) record(fields, values []string) map[string]string {
 	record := make(map[string]string)
 	for idx, field := range fields {
@@ -589,28 +592,19 @@ func (j *Job) record(fields, values []string) map[string]string {
 	return record
 }
 
-func (j *Job) delimiter() string {
+func (j *Job) delimiter() rune {
 	switch ColumnDelimiter(j.info.ColumnDelimiter) {
 	case Tab:
-		return "\t"
+		return '\t'
 	case SemiColon:
-		return ";"
+		return ';'
 	case Pipe:
-		return "|"
+		return '|'
 	case Caret:
-		return "^"
+		return '^'
 	case Backquote:
-		return "`"
+		return '`'
 	default:
-		return ","
-	}
-}
-
-func (j *Job) newline() string {
-	switch LineEnding(j.info.LineEnding) {
-	case CarriageReturnLinefeed:
-		return "\r\n"
-	default:
-		return "\n"
+		return ','
 	}
 }

--- a/bulk/job_test.go
+++ b/bulk/job_test.go
@@ -124,48 +124,6 @@ func TestJob_formatOptions(t *testing.T) {
 	}
 }
 
-func TestJob_newline(t *testing.T) {
-	type fields struct {
-		session session.ServiceFormatter
-		info    Response
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "Carrage return",
-			fields: fields{
-				info: Response{
-					LineEnding: "CRLF",
-				},
-			},
-			want: "\r\n",
-		},
-		{
-			name: "Line feed",
-			fields: fields{
-				info: Response{
-					LineEnding: "LF",
-				},
-			},
-			want: "\n",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := &Job{
-				session: tt.fields.session,
-				info:    tt.fields.info,
-			}
-			if got := j.newline(); got != tt.want {
-				t.Errorf("Job.newline() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestJob_delimiter(t *testing.T) {
 	type fields struct {
 		session session.ServiceFormatter
@@ -174,7 +132,7 @@ func TestJob_delimiter(t *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   string
+		want   rune
 	}{
 		{
 			name: "tab",
@@ -183,7 +141,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "TAB",
 				},
 			},
-			want: "\t",
+			want: '\t',
 		},
 		{
 			name: "back quote",
@@ -192,7 +150,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "BACKQUOTE",
 				},
 			},
-			want: "`",
+			want: '`',
 		},
 		{
 			name: "caret",
@@ -201,7 +159,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "CARET",
 				},
 			},
-			want: "^",
+			want: '^',
 		},
 		{
 			name: "comma",
@@ -210,7 +168,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "COMMA",
 				},
 			},
-			want: ",",
+			want: ',',
 		},
 		{
 			name: "pipe",
@@ -219,7 +177,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "PIPE",
 				},
 			},
-			want: "|",
+			want: '|',
 		},
 		{
 			name: "semi colon",
@@ -228,7 +186,7 @@ func TestJob_delimiter(t *testing.T) {
 					ColumnDelimiter: "SEMICOLON",
 				},
 			},
-			want: ";",
+			want: ';',
 		},
 	}
 	for _, tt := range tests {
@@ -420,7 +378,7 @@ func TestJob_response(t *testing.T) {
 								"fields" : [ "Id" ],
 								"message" : "Account ID: id value of incorrect type: 001900K0001pPuOAAU",
 								"errorCode" : "MALFORMED_ID"
-							}							
+							}
 						]`
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
@@ -764,7 +722,7 @@ func TestJob_setState(t *testing.T) {
 								"fields" : [ "Id" ],
 								"message" : "Account ID: id value of incorrect type: 001900K0001pPuOAAU",
 								"errorCode" : "MALFORMED_ID"
-							}							
+							}
 						]`
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
@@ -895,7 +853,7 @@ func TestJob_infoResponse(t *testing.T) {
 								"fields" : [ "Id" ],
 								"message" : "Account ID: id value of incorrect type: 001900K0001pPuOAAU",
 								"errorCode" : "MALFORMED_ID"
-							}							
+							}
 						]`
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,


### PR DESCRIPTION
Previously, the bulk API wrapper used code which largely duplicates
that in the encoding/csv package. This resulted in inconsistent quoting:
values passed to initial request would return with extra quotes when
inspecting successful, failed, & unprocessed records

This commit removes the code that largely duplicates the provided
csv package. This provides more consistent results between bulk
requests.