### PR TITLE
SOQL queries can return column metadata

### DIFF
--- a/soql/response.go
+++ b/soql/response.go
@@ -57,3 +57,25 @@ func newQueryResponseJSON(jsonMap map[string]interface{}) (QueryResponse, error)
 	}
 	return response, nil
 }
+
+type ColumnMetadata struct {
+	Aggregate      bool             `json:"aggregate"`
+	ApexType       string           `json:"apexType"`
+	BooleanType    bool             `json:"booleanType"`
+	ColumnName     string           `json:"columnName"`
+	Custom         bool             `json:"custom"`
+	DisplayName    string           `json:"displayName"`
+	ForeignKeyName *string          `json:"foreignKeyName"`
+	Insertable     bool             `json:"insertable"`
+	JoinColumns    []ColumnMetadata `json:"joinColumns"`
+	NumberType     bool             `json:"numberType"`
+	TextType       bool             `json:"textType"`
+	Updateable     bool             `json:"updateable"`
+}
+type QueryColumnMetadataResposne struct {
+	EntityName     string           `json:"entityName"`
+	GroupBy        bool             `json:"groupBy"`
+	IdSelected     bool             `json:"idSelected"`
+	KeyPrefix      string           `json:"keyPrefix"`
+	ColumnMetadata []ColumnMetadata `json:"columnMetadata"`
+}

--- a/soql/result.go
+++ b/soql/result.go
@@ -6,9 +6,10 @@ import "errors"
 // allow for retrieving all of the records and query the
 // next round of records if available.
 type QueryResult struct {
-	response QueryResponse
-	records  []*QueryRecord
-	resource *Resource
+	response       QueryResponse
+	records        []*QueryRecord
+	resource       *Resource
+	columnMetadata *QueryColumnMetadataResposne
 }
 
 func NewQueryResult(response QueryResponse, resource *Resource) (*QueryResult, error) {
@@ -56,4 +57,8 @@ func (result *QueryResult) Next() (*QueryResult, error) {
 		return nil, errors.New("soql query result: no more records to query")
 	}
 	return result.resource.next(result.response.NextRecordsURL)
+}
+
+func (result *QueryResult) ColumnMetadata() *QueryColumnMetadataResposne {
+	return result.columnMetadata
 }


### PR DESCRIPTION
Perform "hidden" query to get column metadata. Refactor
query options into opts structure.