### PR TITLE
Allow object/map results from SOQL queries

### DIFF
--- a/record.go
+++ b/record.go
@@ -7,9 +7,10 @@ import (
 
 const (
 	// RecordAttributes is the attribute map from the record JSON
-	RecordAttributes = "attributes"
-	recordAttrType   = "type"
-	recordAttrURL    = "url"
+	RecordAttributes  = "attributes"
+	recordAttrType    = "type"
+	recordAttrURL     = "url"
+	recordAttrRecords = "records"
 )
 
 // Record is a representation of a Salesforce
@@ -76,6 +77,8 @@ func (r *Record) fromJSONMap(jsonMap map[string]interface{}) {
 					if rec, err := RecordFromJSONMap(obj); err == nil {
 						r.lookUps[k] = rec
 					}
+				} else if !r.isSubQueryResult(obj) {
+					r.fields[k] = v
 				}
 			}
 		}
@@ -84,6 +87,11 @@ func (r *Record) fromJSONMap(jsonMap map[string]interface{}) {
 
 func (r *Record) isLookUp(jsonMap map[string]interface{}) bool {
 	_, has := jsonMap[RecordAttributes]
+	return has
+}
+
+func (r *Record) isSubQueryResult(jsonMap map[string]interface{}) bool {
+	_, has := jsonMap[recordAttrRecords]
 	return has
 }
 

--- a/record_test.go
+++ b/record_test.go
@@ -107,6 +107,43 @@ func TestRecord_UnmarshalJSON(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "Successfull Decode address",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+				{
+					"AccountNumber" : "CD656092",
+					"BillingAddress": {
+						"city": "Springfield",
+						"country": "USA",
+						"geocodeAccuracy": null,
+						"latitude": null,
+						"longitude": null,
+						"postalCode": "00001",
+						"state": "CA",
+						"street": "742 Evergreen Terrace"
+					}
+				}`),
+			},
+			want: &Record{
+				fields: map[string]interface{}{
+					"AccountNumber": "CD656092",
+					"BillingAddress": map[string]interface{}{
+						"city":            "Springfield",
+						"country":         "USA",
+						"geocodeAccuracy": nil,
+						"latitude":        nil,
+						"longitude":       nil,
+						"postalCode":      "00001",
+						"state":           "CA",
+						"street":          "742 Evergreen Terrace",
+					},
+				},
+				lookUps: map[string]*Record{},
+			},
+			wantErr: false,
+		},
+		{
 			name:   "Error Decode",
 			fields: fields{},
 			args: args{
@@ -339,6 +376,16 @@ func TestRecordFromJSONMap(t *testing.T) {
 							},
 						},
 					},
+					"BillingAddress": map[string]interface{}{
+						"city":            "Springfield",
+						"country":         "USA",
+						"geocodeAccuracy": nil,
+						"latitude":        nil,
+						"longitude":       nil,
+						"postalCode":      "00001",
+						"state":           "CA",
+						"street":          "742 Evergreen Terrace",
+					},
 				},
 			},
 			want: &Record{
@@ -346,6 +393,16 @@ func TestRecordFromJSONMap(t *testing.T) {
 				url:     "/services/data/v20.0/sobjects/Account/001D000000IRFmaIAH",
 				fields: map[string]interface{}{
 					"Name": "Test 1",
+					"BillingAddress": map[string]interface{}{
+						"city":            "Springfield",
+						"country":         "USA",
+						"geocodeAccuracy": nil,
+						"latitude":        nil,
+						"longitude":       nil,
+						"postalCode":      "00001",
+						"state":           "CA",
+						"street":          "742 Evergreen Terrace",
+					},
 				},
 				lookUps: map[string]*Record{},
 			},


### PR DESCRIPTION
SOQL query results may contain objects/map if they are a lookup or compound type (address or location). Previously the code failed to populate the record with the object value if it was not a lookup. This change populates record fields of type address or location with the value.